### PR TITLE
Add NixOS options and darp6 support with new and updated packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Supported models
 | Model                | Contributors      | Status |
 | -------------------- | ----------------- | ------ |
 | `oryp4`              | [stites][stites]  | Active development |
+| `darp6`              | [khumba][khumba]  |        |
 
 [stites]: https://github.com/stites
+[khumba]: https://github.com/khumba
 
 I'm only going to claim to support the 2018 Oryx Pro build (oryp4) since it's the one I actively use. That said, this repo will try to add nixos support to all system76-development repositories, attempting to reach parity with [system76-dev's stable PPA](https://launchpad.net/~system76-dev/+archive/ubuntu/stable). This _does_ mean that this repo will be opinionated about which kernels you can support.
 
@@ -18,9 +20,11 @@ Repositories tracked (as well as last known release and status):
 
 | Package                                                              | Last known release | Last release date | Last checked | Notes  |
 | -------------------------------------------------------------------- | ------------------ | ----------------- | ------------ | ------ |
-| [system76-firmware](https://github.com/pop-os/system76-firmware)     | 1.0.2              | 05/08/2019        | 02/06/2018   | untested |
-| [system76-dkms](https://github.com/pop-os/system76-dkms)             | 1.0.4              | 02/06/2019        | 02/06/2018   | untested |
+| [system76-acpi-dkms](https://github.com/pop-os/system76-acpi-dkms)   | 1.0.1              | 10/15/2019        | 03/22/2020   | incomplete |
+| [system76-dkms](https://github.com/pop-os/system76-dkms)             | 1.0.6              | 06/06/2019        | 03/22/2020   | untested |
 | [system76-driver](https://github.com/pop-os/system76-driver)         | 19.04.2            | 01/31/2019        | 02/06/2018   | incomplete |
+| [system76-io-dkms](https://github.com/pop-os/system76-io-dkms)       | 1.0.1              | 06/04/2019        | 03/22/2020   | incomplete |
+| [system76-firmware](https://github.com/pop-os/system76-firmware)     | 1.0.2              | 05/08/2019        | 02/06/2018   | untested |
 | [system76-power](https://github.com/pop-os/system76-power)           | none               | 02/06/2019        | 02/06/2018   | incomplete |
 | [hidpi-daemon](https://github.com/pop-os/hidpi-daemon)               | 18.04.4            | 08/01/2018        | 02/06/2018   | incomplete |
 | [gtk-theme](https://github.com/pop-os/gtk-theme)                     | 4.0.0-b2           | 08/09/2018        | 02/06/2018   | incomplete, low priority |
@@ -39,6 +43,12 @@ clone this repo in your `/etc/nixos/` folder. Add this folder as an import in `/
 ```
 # in /etc/nixos/configuration.nix
 {
+  hardware.system76.enable = true;
+
+  # Supported options: generic (default), darp6
+  # This controls which kernel modules are installed.
+  #hardware.system76.model = "generic";
+
   # for nvidia-supported laptops
   nixpkgs.config.allowUnfree = true;
 
@@ -53,7 +63,7 @@ clone this repo in your `/etc/nixos/` folder. Add this folder as an import in `/
 
       # if you want something more granular
      "${builtins.fetchGit { url="https://github.com/stites/system76-nixos"; ref="master"; }}/if-you-want-a-specific-file.nix"
-   ]
+   ];
 }
 ```
 

--- a/build.nix
+++ b/build.nix
@@ -3,7 +3,9 @@ let
     # allowUnfree = true;
     packageOverrides = pkgs: {
       linuxPackages = pkgs.linuxPackages.extend(self: super: {
+        system76-acpi-dkms = self.callPackage ./system76-acpi-dkms {};
         system76-dkms = self.callPackage ./system76-dkms {};
+        system76-io-dkms = self.callPackage ./system76-io-dkms {};
         system76-firmware = self.callPackage ./system76-firmware {};
         system76-driver = self.callPackage ./system76-driver {};
       });
@@ -18,10 +20,14 @@ let
   }) { inherit config; };
 
 in with pkgs; {
+  system76-acpi-dkms_beta    = linuxPackages.system76-acpi-dkms.beta;
+  system76-acpi-dkms_stable  = linuxPackages.system76-acpi-dkms.stable;
   system76-dkms_beta         = linuxPackages.system76-dkms.beta;
   system76-dkms_stable       = linuxPackages.system76-dkms.stable;
   system76-dkms_legacy_1_0_1 = linuxPackages.system76-dkms.legacy_1_0_1;
   system76-dkms_legacy_1_0_0 = linuxPackages.system76-dkms.legacy_1_0_0;
+  system76-io-dkms_beta      = linuxPackages.system76-io-dkms.beta;
+  system76-io-dkms_stable    = linuxPackages.system76-io-dkms.stable;
   system76-firmware          = linuxPackages.system76-firmware;
   system76-driver-v19_04_3   = linuxPackages.system76-driver.v19_04_3;
   system76-driver-v18_10_6   = linuxPackages.system76-driver.v18_10_6;

--- a/default.nix
+++ b/default.nix
@@ -1,25 +1,79 @@
-{ latest ? false }: { config, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
+let
+  cfg = config.hardware.system76;
+
+  # Supported laptop models.  Models for which the generic configuration isn't
+  # specific can be added here.
+  supportedModels = [ "generic" "darp6" ];
+
+  # darp6 needs system76-acpi-dkms, not system76-dkms:
+  #
+  # [1] https://github.com/pop-os/system76-dkms/issues/39
+  # jackpot51> system76-acpi-dkms is the correct driver to use on the darp6
+  #
+  # system76-io-dkms also appears to be loaded on darp6 with Pop!_OS, and
+  # system76-dkms does not.
+
+  useAcpiDkms = builtins.elem cfg.model [ "darp6" ];
+
+  useIoDkms = builtins.elem cfg.model [ "darp6" ];
+
+  # In absense of more knowledge, we install system76-dkms for all other models.
+  useDkms = !builtins.elem cfg.model [ "darp6" ];
+
+  kernelPackages = let inherit (config.boot.kernelPackages) callPackage; in {
+    system76-acpi-dkms = (callPackage ./system76-acpi-dkms {}).${cfg.release};
+    system76-io-dkms = (callPackage ./system76-io-dkms {}).${cfg.release};
+    system76-dkms = (callPackage ./system76-dkms {}).${cfg.release};
+  };
+in
 {
-  boot.kernelPackages = if latest then pkgs.linuxPackages_latest else pkgs.linuxPackages;
+  options.hardware.system76 = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to enable support for System76 hardware.
+      '';
+    };
 
-  # This is required for system76-driver, I believe. Can I just add this to the nix script?
-  boot.kernelParams = [ "ec_sys.write_support=1" ];
+    model = lib.mkOption {
+      type = lib.types.enum supportedModels;
+      default = "generic";
+      description = ''
+        The model of System76 laptop to configure for.  This determines which
+        kernel drivers will be used.  If there is no specific support for your
+        model, a generic configuration may be used.
+      '';
+    };
 
-  # Imports the overlay
-  nixpkgs.overlays = [
-    (self: super: {
-      linuxPackages_latest = super.linuxPackages_latest.extend(lpself: lpsuper: {
-        system76-dkms = (lpself.callPackage ./system76-dkms {}).stable;
-      });
-      linuxPackages = super.linuxPackages.extend(lpself: lpsuper: {
-        system76-dkms = (lpself.callPackage ./system76-dkms {}).stable;
-      });
-    })
-  ];
+    release = lib.mkOption {
+      type = lib.types.enum [ "beta" "stable" ];
+      default = "stable";
+      example = "beta";
+      description = ''
+        Whether to use stable or beta versions of System76 software releases.
+      '';
+    };
+  };
 
-  boot.extraModulePackages = [ (if latest then pkgs.linuxPackages_latest else pkgs.linuxPackages).system76-dkms ];
+  config = lib.mkIf cfg.enable {
+    # This is required for system76-driver, I believe. Can I just add this to the nix script?
+    boot.kernelParams = [ "ec_sys.write_support=1" ];
 
-  # This line I think is not needed. Depends on when I'm supposed to load this
-  # boot.kernelModules = [ "system76" ];
+    boot.extraModulePackages =
+      lib.optional useAcpiDkms kernelPackages.system76-acpi-dkms ++
+      lib.optional useIoDkms kernelPackages.system76-io-dkms ++
+      lib.optional useDkms kernelPackages.system76-dkms;
+
+    # system76_acpi automatically loads on darp6, but system76_io does not.
+    # Explicitly load both for consistency.
+    boot.kernelModules =
+      lib.optional useAcpiDkms "system76_acpi" ++
+      lib.optional useIoDkms "system76_io" ++
+      # This line I think is not needed. Depends on when I'm supposed to load this
+      [];  # lib.optional useDkms "system76"
+  };
 }

--- a/system76-acpi-dkms/default.nix
+++ b/system76-acpi-dkms/default.nix
@@ -1,0 +1,13 @@
+{ lib, callPackage }:
+
+let
+  generic = args: callPackage (import ./generic.nix args) { };
+in
+
+rec {
+  beta = stable;
+  stable = generic {
+    version = "1.0.1";
+    sha = "0jmm9h607f7k20yassm6af9mh5l00yih5248wwv4i05bd68yw3p5";
+  };
+}

--- a/system76-acpi-dkms/generic.nix
+++ b/system76-acpi-dkms/generic.nix
@@ -1,0 +1,47 @@
+{version, rev ? version, sha}: { stdenv, fetchFromGitHub, fetchpatch, kernel }:
+
+stdenv.mkDerivation {
+  name = "system76-acpi-dkms-${version}";
+  version = "${version}";
+
+  src = fetchFromGitHub {
+      owner = "pop-os";
+      repo = "system76-acpi-dkms";
+      inherit rev;
+      sha256 = "${sha}";
+    };
+
+  hardeningDisable = [ "pic" ];
+  dontStrip = true;
+  dontPatchELF = true;
+
+  kernel = kernel.dev;
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  preBuild = ''
+    sed -e "s@/lib/modules/\$(.*)@${kernel.dev}/lib/modules/${kernel.modDirVersion}@" -i Makefile
+  '';
+
+  outputs = [ "out" ];
+  installPhase = ''
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/misc
+    cp system76_acpi.ko $out/lib/modules/${kernel.modDirVersion}/misc
+
+    # not sure if these are working
+    mkdir -p $out/usr/share/initramfs-tools/hooks
+    cp {$src,$out}/usr/share/initramfs-tools/hooks/system76-acpi-dkms
+
+    mkdir -p $out/usr/share/initramfs-tools/modules.d
+    cp {$src,$out}/usr/share/initramfs-tools/modules.d/system76-acpi-dkms.conf
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.khumba ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    description = "System76 ACPI Driver (DKMS)";
+    homepage = https://github.com/pop-os/system76-acpi-dkms;
+    longDescription = ''
+      This provides the system76_acpi in-tree driver for systems missing it.
+    '';
+  };
+}

--- a/system76-dkms/default.nix
+++ b/system76-dkms/default.nix
@@ -6,8 +6,8 @@ in
 
 rec {
   beta = generic {
-    version = "1.0.4";
-    sha = "03fm40gf9962jcwb4yj90pa2269nlbg1w2wpwaa8j2kq9263fkh2";
+    version = "1.0.6";
+    sha = "0263aqm0aibnfhy1m99nj36c7p2327a3aqk5by2nm2mjm3sqr5zc";
   };
   stable = generic {
     version = "1.0.3";

--- a/system76-io-dkms/default.nix
+++ b/system76-io-dkms/default.nix
@@ -1,0 +1,13 @@
+{ lib, callPackage }:
+
+let
+  generic = args: callPackage (import ./generic.nix args) { };
+in
+
+rec {
+  beta = stable;
+  stable = generic {
+    version = "1.0.1";
+    sha = "0qkgkkjy1isv6ws6hrcal75dxjz98rpnvqbm7agdcc6yv0c17wwh";
+  };
+}

--- a/system76-io-dkms/generic.nix
+++ b/system76-io-dkms/generic.nix
@@ -1,0 +1,44 @@
+{version, rev ? version, sha}: { stdenv, fetchFromGitHub, fetchpatch, kernel }:
+
+stdenv.mkDerivation {
+  name = "system76-io-dkms-${version}";
+  version = "${version}";
+
+  src = fetchFromGitHub {
+      owner = "pop-os";
+      repo = "system76-io-dkms";
+      inherit rev;
+      sha256 = "${sha}";
+    };
+
+  hardeningDisable = [ "pic" ];
+  dontStrip = true;
+  dontPatchELF = true;
+
+  kernel = kernel.dev;
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  preBuild = ''
+    sed -e "s@/lib/modules/\$(.*)@${kernel.dev}/lib/modules/${kernel.modDirVersion}@" -i Makefile
+  '';
+
+  outputs = [ "out" ];
+  installPhase = ''
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/misc
+    cp system76-io.ko $out/lib/modules/${kernel.modDirVersion}/misc
+
+    # not sure if these are working
+    mkdir -p $out/usr/share/initramfs-tools/hooks
+    cp {$src,$out}/usr/share/initramfs-tools/hooks/system76-io-dkms
+
+    mkdir -p $out/usr/share/initramfs-tools/modules.d
+    cp {$src,$out}/usr/share/initramfs-tools/modules.d/system76-io-dkms.conf
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.khumba ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    description = "DKMS module for controlling System76 Io board";
+    homepage = https://github.com/pop-os/system76-io-dkms;
+  };
+}


### PR DESCRIPTION
Hello, @stites!  Thanks very much for supporting System76 on NixOS.  I got a Darter recently and was really happy to see that you'd already done all this work.

Primarily, this PR adds support for the Darter Pro model darp6 currently being shipped by System76.  I've just completed an install of NixOS unstable based on these changes.  I have the keyboard backlight controls working, and the two kernel modules are loaded that were also loaded under Pop!_OS: `system76-acpi-dkms` and `system76-io-dkms`.

This also adds NixOS options for configuring System76 support under `hardware.system76`.

I also bumped the `system76-dkms` beta version from 1.0.4 to 1.0.6; initially I thought this driver was needed for darp6, but it seems it's not (despite there being an unreleased commit adding entries for it to the code, the module refuses to load).